### PR TITLE
Added RSA version field check

### DIFF
--- a/crypto/rsa/rsa_asn1.c
+++ b/crypto/rsa/rsa_asn1.c
@@ -39,8 +39,14 @@ static int rsa_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
         return 2;
     } else if (operation == ASN1_OP_D2I_POST) {
         if (((RSA *)*pval)->version != RSA_ASN1_VERSION_MULTI) {
-            /* not a multi-prime key, skip */
-            return 1;
+            /* not a multi-prime key, check default version */
+            if (((RSA *)*pval)->version == RSA_ASN1_VERSION_DEFAULT) {
+                return 1;
+            } else {
+                /* not default or multi-prime, invalid version*/
+                ERR_raise(ERR_LIB_ASN1, ASN1_R_ASN1_PARSE_ERROR);
+                return NULL;
+            }
         }
         return (ossl_rsa_multip_calc_product((RSA *)*pval) == 1) ? 2 : 0;
     }


### PR DESCRIPTION
Fixes [#26467](https://github.com/openssl/openssl/issues/26467)

The following PR addresses issue with openssl not verifying the version field when parsing RSA_PRIVATE_KEY_PEM as required by RFC 8017:
"version is the version number, for compatibility with future revisions of this document. It SHALL be 0 for this version of the document, unless multi-prime is used; in which case, it SHALL be 1."

PR validates version field as either 1 or 0 and raises error/returns null if value does not match either of these.

Tagging: @bbbrumley
Tagging: @mineo333
