### PR TITLE
Fixed chacha20 get updated IV

### DIFF
--- a/providers/implementations/ciphers/cipher_chacha20.c
+++ b/providers/implementations/ciphers/cipher_chacha20.c
@@ -94,6 +94,7 @@ static int chacha20_get_params(OSSL_PARAM params[])
 
 static int chacha20_get_ctx_params(void *vctx, OSSL_PARAM params[])
 {
+    PROV_CHACHA20_CTX *ctx = (PROV_CHACHA20_CTX *)vctx;
     OSSL_PARAM *p;
 
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_IVLEN);
@@ -103,6 +104,13 @@ static int chacha20_get_ctx_params(void *vctx, OSSL_PARAM params[])
     }
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_KEYLEN);
     if (p != NULL && !OSSL_PARAM_set_size_t(p, CHACHA20_KEYLEN)) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+        return 0;
+    }
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_UPDATED_IV);
+    if (p != NULL
+        && !OSSL_PARAM_set_octet_ptr(p, &ctx->counter, CHACHA20_IVLEN)
+        && !OSSL_PARAM_set_octet_string(p, &ctx->counter, CHACHA20_IVLEN)) {
         ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
         return 0;
     }


### PR DESCRIPTION
Fixes [#26998](https://github.com/openssl/openssl/issues/26998)

The following PR addresses an issue where the EVP_CIPHER_CTX_get_updated_iv() function does not properly return the updated IV for the ChaCha20 cipher. chacha20_get_ctx_params was updated to be sensitive to the OSSL_CIPHER_PARAM_UPDATED_IV parameter. Actual output now matches expected output as provided by iucoen.

Testing AES-256-CTR
Original IV: 0102030405060708090a0b0c0d0e0f10
Updated IV: 0102030405060708090a0b0c0d0e0f14

Testing ChaCha20
Original IV: 0102030405060708090a0b0c0d0e0f10
Updated IV: 0202030405060708090a0b0c0d0e0f10


Tagging: @bbbrumley
Tagging: @mineo333